### PR TITLE
feat: add spaces/[identifier] page

### DIFF
--- a/apps/app/src/app/[slug]/(sidebar)/spaces/[identifier]/page.tsx
+++ b/apps/app/src/app/[slug]/(sidebar)/spaces/[identifier]/page.tsx
@@ -1,0 +1,30 @@
+import { ActivitySection } from '@/components/features/activity/activity-section';
+import { SpaceHeader } from '@/components/features/space/space-header';
+import { SpacePublishedPostsList } from '@/components/features/space/space-posts-list';
+import { getQueryClient, HydrateClient, trpc } from '@/trpc/server';
+
+export default async function SpacesPage({
+  params,
+}: {
+  params: Promise<{ identifier: string }>;
+}) {
+  const { identifier } = await params;
+  const queryClient = getQueryClient();
+
+  await queryClient.prefetchQuery(
+    trpc.space.getSpaceWithPublishedPosts.queryOptions({ identifier })
+  );
+
+  return (
+    <HydrateClient>
+      <div className="flex h-full w-full gap-1.5 overflow-hidden">
+        <div className="flex-1 rounded border bg-background">
+          <SpaceHeader identifier={identifier} />
+          <ActivitySection>
+            <SpacePublishedPostsList identifier={identifier} />
+          </ActivitySection>
+        </div>
+      </div>
+    </HydrateClient>
+  );
+}

--- a/apps/app/src/app/[slug]/(sidebar)/spaces/[identifier]/page.tsx
+++ b/apps/app/src/app/[slug]/(sidebar)/spaces/[identifier]/page.tsx
@@ -1,6 +1,8 @@
+import { Sidebar, SidebarContent } from '@coordinize/ui/components/sidebar';
 import { ActivitySection } from '@/components/features/activity/activity-section';
 import { SpaceHeader } from '@/components/features/space/space-header';
 import { SpacePublishedPostsList } from '@/components/features/space/space-posts-list';
+import { SpaceSidebar } from '@/components/features/space/space-sidebar';
 import { getQueryClient, HydrateClient, trpc } from '@/trpc/server';
 
 export default async function SpacesPage({
@@ -17,13 +19,28 @@ export default async function SpacesPage({
 
   return (
     <HydrateClient>
-      <div className="flex h-full w-full gap-1.5 overflow-hidden">
-        <div className="flex-1 rounded border bg-background">
-          <SpaceHeader identifier={identifier} />
-          <ActivitySection>
-            <SpacePublishedPostsList identifier={identifier} />
-          </ActivitySection>
+      <div className="flex h-full w-full">
+        <div className="flex-1">
+          <div className="flex h-full flex-col overflow-hidden rounded border bg-background">
+            <SpaceHeader identifier={identifier} />
+            <div className="flex-1 overflow-auto">
+              <ActivitySection>
+                <SpacePublishedPostsList identifier={identifier} />
+              </ActivitySection>
+            </div>
+          </div>
         </div>
+
+        <Sidebar
+          className="border-none"
+          collapsible="offcanvas"
+          side="right"
+          variant="sidebar"
+        >
+          <SidebarContent>
+            <SpaceSidebar identifier={identifier} />
+          </SidebarContent>
+        </Sidebar>
       </div>
     </HydrateClient>
   );

--- a/apps/app/src/components/features/activity/post-item.tsx
+++ b/apps/app/src/components/features/activity/post-item.tsx
@@ -36,8 +36,10 @@ export function PostItem({
         <div className="flex min-w-0 flex-1 flex-col gap-0">
           <div className="flex min-w-0 select-none items-center gap-2">
             <h1 className="truncate font-medium text-[15px]">{title}</h1>
-            <Dot />
-            <p className="truncate font-medium text-[15px]">{spaceName}</p>
+            <Dot className="hidden sm:flex" />
+            <p className="hidden truncate font-medium text-[15px] sm:flex">
+              {spaceName}
+            </p>
           </div>
           <p className="line-clamp-1 text-sm text-ui-gray-900">
             {stripHtml(description || '')}

--- a/apps/app/src/components/features/post/post-header.tsx
+++ b/apps/app/src/components/features/post/post-header.tsx
@@ -10,17 +10,10 @@ import { PostOptions } from './post-options';
 interface PostHeaderProps {
   space: string;
   title: string;
-  openDetails: boolean;
-  onOpenDetails: (open: boolean) => void;
 }
 
-export function PostHeader({
-  space,
-  title,
-  openDetails,
-  onOpenDetails,
-}: PostHeaderProps) {
-  const { isMobile, state } = useSidebar();
+export function PostHeader({ space, title }: PostHeaderProps) {
+  const { isMobile, leftState } = useSidebar();
 
   return (
     <header className="flex items-center justify-between px-2 py-1">
@@ -28,10 +21,13 @@ export function PostHeader({
         <div
           className={cn(
             'flex h-full items-center',
-            isMobile || state === 'collapsed' ? 'flex' : 'hidden'
+            isMobile || leftState === 'collapsed' ? 'flex' : 'hidden'
           )}
         >
-          <SidebarTrigger className="size-7 rounded-sm text-muted-foreground" />
+          <SidebarTrigger
+            className="size-7 rounded-sm text-muted-foreground"
+            side="left"
+          />
         </div>
 
         <div className="flex items-center gap-1">
@@ -56,18 +52,10 @@ export function PostHeader({
       </div>
       <div className="flex items-center gap-2">
         <PostOptions />
-        <Button
-          className={cn(
-            'size-7 rounded-sm text-muted-foreground focus-visible:ring-0'
-          )}
-          onClick={() => onOpenDetails(!openDetails)}
-          size={'icon'}
-          tooltip={openDetails ? 'Close details' : 'Open details'}
-          tooltipShortcut="]"
-          variant={'ghost'}
-        >
-          <Icons.panelRight />
-        </Button>
+        <SidebarTrigger
+          className="size-7 rounded-sm text-muted-foreground focus-visible:ring-0"
+          side="right"
+        />
       </div>
     </header>
   );

--- a/apps/app/src/components/features/post/post-page-content.tsx
+++ b/apps/app/src/components/features/post/post-page-content.tsx
@@ -2,9 +2,9 @@
 
 import { Button } from '@coordinize/ui/components/button';
 import { Separator } from '@coordinize/ui/components/separator';
+import { Sidebar, SidebarContent } from '@coordinize/ui/components/sidebar';
 import { Icons } from '@coordinize/ui/lib/icons';
 import { cn } from '@coordinize/ui/lib/utils';
-import { useEffect, useState } from 'react';
 import { ActivitySection } from '@/components/features/activity/activity-section';
 import { PostActivitySection } from '@/components/features/post/post-activity-section';
 import { PostContent } from '@/components/features/post/post-content';
@@ -31,65 +31,44 @@ interface PostPageContentProps {
 }
 
 export function PostPageContent({ post }: PostPageContentProps) {
-  const [openDetails, setOpenDetails] = useState(true);
-
-  // Keyboard shortcut to toggle sidebar
-  useEffect(() => {
-    const handleKeyDown = (event: KeyboardEvent) => {
-      if (event.key === ']') {
-        event.preventDefault();
-        setOpenDetails((prev) => !prev);
-      }
-    };
-
-    window.addEventListener('keydown', handleKeyDown);
-    return () => window.removeEventListener('keydown', handleKeyDown);
-  }, []);
-
   return (
-    <div className="flex h-full w-full overflow-hidden">
-      <div className="flex h-full flex-1 flex-col overflow-hidden rounded border bg-background">
-        <PostHeader
-          onOpenDetails={setOpenDetails}
-          openDetails={openDetails}
-          space={post.space.name}
-          title={post.title}
-        />
-        <div className="flex-1 overflow-auto">
-          <ActivitySection>
-            <PostMetadata
-              createdAt={post.createdAt}
-              userImage={post.author.image || ''}
-              userName={post.author.name}
-            />
-            <PostContent content={post.content || ''} title={post.title} />
-            <Button
-              className={cn('size-7 rounded-sm text-muted-foreground')}
-              size={'icon'}
-              tooltip="Add a reaction"
-              variant={'ghost'}
-            >
-              <Icons.emojiPlus size={16} />
-            </Button>
-            <Separator />
-            <PostActivitySection />
-          </ActivitySection>
+    <div className="flex h-full w-full">
+      <div className="flex-1">
+        <div className="flex h-full flex-col overflow-hidden rounded border bg-background">
+          <PostHeader space={post.space.name} title={post.title} />
+          <div className="flex-1 overflow-auto">
+            <ActivitySection>
+              <PostMetadata
+                createdAt={post.createdAt}
+                userImage={post.author.image || ''}
+                userName={post.author.name}
+              />
+              <PostContent content={post.content || ''} title={post.title} />
+              <Button
+                className={cn('size-7 rounded-sm text-muted-foreground')}
+                size={'icon'}
+                tooltip="Add a reaction"
+                variant={'ghost'}
+              >
+                <Icons.emojiPlus size={16} />
+              </Button>
+              <Separator />
+              <PostActivitySection />
+            </ActivitySection>
+          </div>
         </div>
       </div>
-      <div
-        className={cn(
-          'relative bg-transparent transition-[width] duration-200 ease-linear',
-          openDetails ? 'w-60' : 'w-0'
-        )}
-      />
-      <div
-        className={cn(
-          'fixed inset-y-0 right-0 z-10 h-svh w-60 transition-[right] duration-200 ease-linear',
-          openDetails ? 'right-0' : 'right-[-20rem]'
-        )}
+
+      <Sidebar
+        className="border-none"
+        collapsible="offcanvas"
+        side="right"
+        variant="sidebar"
       >
-        <PostSidebar postId={post.id} spaceName={post.space.name} />
-      </div>
+        <SidebarContent>
+          <PostSidebar postId={post.id} spaceName={post.space.name} />
+        </SidebarContent>
+      </Sidebar>
     </div>
   );
 }

--- a/apps/app/src/components/features/post/post-sidebar.tsx
+++ b/apps/app/src/components/features/post/post-sidebar.tsx
@@ -1,8 +1,6 @@
 'use client';
 
 import {
-  Sidebar,
-  SidebarContent,
   SidebarGroup,
   SidebarGroupLabel,
   SidebarMenu,
@@ -20,30 +18,21 @@ interface PostSidebarProps {
 
 export function PostSidebar({ spaceName, postId }: PostSidebarProps) {
   return (
-    <div className="flex h-full w-full flex-col bg-sidebar">
-      <Sidebar
-        className="h-full border-none"
-        collapsible="none"
-        side="right"
-        variant="inset"
-      >
-        <SidebarContent>
-          <SpaceGroup spaceName={spaceName} />
-          <SidebarGroup className="pl-0">
-            <SidebarGroupLabel>Subscribe</SidebarGroupLabel>
-            <SidebarMenu>
-              <SidebarMenuItem>
-                <div className="flex items-center justify-between p-2 text-sm">
-                  <span className="select-none">New Activity</span>
-                  <Switch defaultChecked />
-                </div>
-              </SidebarMenuItem>
-            </SidebarMenu>
-          </SidebarGroup>
-          <PostSidebarActions postId={postId} />
-        </SidebarContent>
-        <PostSidebarFooter postId={postId} />
-      </Sidebar>
+    <div className="flex h-full w-full flex-col">
+      <SpaceGroup spaceName={spaceName} />
+      <SidebarGroup className="pl-0">
+        <SidebarGroupLabel>Subscribe</SidebarGroupLabel>
+        <SidebarMenu>
+          <SidebarMenuItem>
+            <div className="flex items-center justify-between p-2 text-sm">
+              <span className="select-none">New Activity</span>
+              <Switch defaultChecked />
+            </div>
+          </SidebarMenuItem>
+        </SidebarMenu>
+      </SidebarGroup>
+      <PostSidebarActions postId={postId} />
+      <PostSidebarFooter postId={postId} />
     </div>
   );
 }

--- a/apps/app/src/components/features/space/space-header.tsx
+++ b/apps/app/src/components/features/space/space-header.tsx
@@ -12,7 +12,7 @@ interface SpaceHeaderProps {
 }
 
 export function SpaceHeader({ identifier }: SpaceHeaderProps) {
-  const { isMobile, state } = useSidebar();
+  const { isMobile, leftState } = useSidebar();
   const { data: space } = useSpaceWithPublishedPostsQuery(identifier);
 
   return (
@@ -21,7 +21,7 @@ export function SpaceHeader({ identifier }: SpaceHeaderProps) {
         <div
           className={cn(
             'flex h-full items-center',
-            isMobile || state === 'collapsed' ? 'flex' : 'hidden'
+            isMobile || leftState === 'collapsed' ? 'flex' : 'hidden'
           )}
         >
           <SidebarTrigger className="size-7 rounded-sm text-muted-foreground" />
@@ -45,6 +45,10 @@ export function SpaceHeader({ identifier }: SpaceHeaderProps) {
           <Icons.star />
         </Button>
       </div>
+      <SidebarTrigger
+        className="size-7 rounded-sm text-muted-foreground focus-visible:ring-0"
+        side="right"
+      />
     </header>
   );
 }

--- a/apps/app/src/components/features/space/space-header.tsx
+++ b/apps/app/src/components/features/space/space-header.tsx
@@ -1,0 +1,50 @@
+'use client';
+
+import { Button } from '@coordinize/ui/components/button';
+import { Label } from '@coordinize/ui/components/label';
+import { SidebarTrigger, useSidebar } from '@coordinize/ui/components/sidebar';
+import { Icons } from '@coordinize/ui/lib/icons';
+import { cn } from '@coordinize/ui/lib/utils';
+import { useSpaceWithPublishedPostsQuery } from '@/hooks/use-space';
+
+interface SpaceHeaderProps {
+  identifier: string;
+}
+
+export function SpaceHeader({ identifier }: SpaceHeaderProps) {
+  const { isMobile, state } = useSidebar();
+  const { data: space } = useSpaceWithPublishedPostsQuery(identifier);
+
+  return (
+    <header className="flex items-center justify-between px-2 py-1">
+      <div className="flex h-full items-center gap-3">
+        <div
+          className={cn(
+            'flex h-full items-center',
+            isMobile || state === 'collapsed' ? 'flex' : 'hidden'
+          )}
+        >
+          <SidebarTrigger className="size-7 rounded-sm text-muted-foreground" />
+        </div>
+        <div className="flex items-center gap-1">
+          <Label className="font-normal">
+            <Icons.space size={16} />
+            Spaces
+          </Label>
+          <span className="text-ui-gray-900">/</span>
+          <Label className="font-normal">
+            {space?.name || 'Unknown Space'}
+          </Label>
+        </div>
+        <Button
+          className={cn('size-7 rounded-sm text-muted-foreground')}
+          size={'icon'}
+          tooltip="Add to your favorites"
+          variant={'ghost'}
+        >
+          <Icons.star />
+        </Button>
+      </div>
+    </header>
+  );
+}

--- a/apps/app/src/components/features/space/space-posts-list.tsx
+++ b/apps/app/src/components/features/space/space-posts-list.tsx
@@ -1,0 +1,86 @@
+'use client';
+
+import type { Post, User } from '@coordinize/database/db';
+import { isToday, isYesterday } from 'date-fns';
+import { useParams } from 'next/navigation';
+import { PostItem } from '@/components/features/activity/post-item';
+import { DaySeparator } from '@/components/ui/day-seperator';
+import { useSpaceWithPublishedPostsQuery } from '@/hooks/use-space';
+import { formatDate } from '@/utils/format-date';
+
+type PostWithRelations = Post & {
+  author: Pick<User, 'id' | 'name' | 'image'> | null;
+};
+
+export function SpacePublishedPostsList({
+  identifier,
+}: {
+  identifier: string;
+}) {
+  const { data: space } = useSpaceWithPublishedPostsQuery(identifier);
+  const { slug: workspaceSlug } = useParams<{ slug: string }>();
+
+  function getDateLabel(publishedAt: Date | null): string {
+    if (!publishedAt) {
+      return 'Older';
+    }
+
+    const date = new Date(publishedAt);
+
+    if (isToday(date)) {
+      return 'Today';
+    }
+    if (isYesterday(date)) {
+      return 'Yesterday';
+    }
+
+    return formatDate(date);
+  }
+
+  function groupPostsByDate(
+    posts: PostWithRelations[]
+  ): Record<string, PostWithRelations[]> {
+    const groups: Record<string, PostWithRelations[]> = {};
+
+    for (const post of posts) {
+      if (!post.publishedAt) {
+        continue;
+      }
+
+      const label = getDateLabel(post.publishedAt);
+
+      if (!groups[label]) {
+        groups[label] = [];
+      }
+      groups[label]?.push(post);
+    }
+
+    return groups;
+  }
+
+  const groupedPosts = groupPostsByDate(space?.posts || []);
+
+  return (
+    <>
+      {Object.entries(groupedPosts).map(([dateLabel, posts]) => (
+        <div className="flex flex-col gap-6" key={dateLabel}>
+          <DaySeparator label={dateLabel} />
+          <div className="flex flex-col gap-4">
+            {posts.map((post) => (
+              <PostItem
+                authorName={post.author?.name || 'Unknown Author'}
+                description={post.content || undefined}
+                id={post.id}
+                key={post.id}
+                spaceName={space?.name || 'Unknown Space'}
+                title={post.title}
+                userImage={post.author?.image || undefined}
+                workspaceSlug={workspaceSlug}
+              />
+            ))}
+          </div>
+        </div>
+      ))}
+    </>
+  );
+}

--- a/apps/app/src/components/features/space/space-sidebar.tsx
+++ b/apps/app/src/components/features/space/space-sidebar.tsx
@@ -1,0 +1,74 @@
+'use client';
+
+import { Button } from '@coordinize/ui/components/button';
+import {
+  SidebarGroup,
+  SidebarGroupContent,
+  SidebarGroupLabel,
+  SidebarMenu,
+  SidebarMenuItem,
+} from '@coordinize/ui/components/sidebar';
+import { Switch } from '@coordinize/ui/components/switch';
+import { Icons } from '@coordinize/ui/lib/icons';
+import AvatarStatus from '@/components/ui/avatar-status';
+import { useSpaceWithPublishedPostsQuery } from '@/hooks/use-space';
+
+interface SpaceSidebarProps {
+  identifier: string;
+}
+
+export function SpaceSidebar({ identifier }: SpaceSidebarProps) {
+  const { data: space } = useSpaceWithPublishedPostsQuery(identifier);
+
+  const membersCount = space?.members.length || 0;
+  return (
+    <div className="flex h-full w-full flex-col">
+      <SidebarGroup className="pl-0">
+        <SidebarGroupLabel>About</SidebarGroupLabel>
+        <p className="px-2 text-sm">
+          {space?.about || 'No description available.'}
+        </p>
+      </SidebarGroup>
+      <SidebarGroup className="pl-0">
+        <SidebarGroupLabel>
+          {membersCount} member{membersCount !== 1 ? 's' : ''}
+        </SidebarGroupLabel>
+        <SidebarGroupContent className="flex items-center">
+          {space?.members.map((member) => (
+            <div
+              className="flex items-center gap-2 px-2 py-1"
+              key={member.user.id}
+            >
+              <AvatarStatus
+                alt={member.user.name}
+                className="size-6"
+                fallback={member.user.name}
+                src={member.user.image ?? ''}
+              />
+            </div>
+          ))}
+          <Button
+            className="size-7 rounded-full"
+            size={'icon'}
+            tooltip="Add member"
+            variant={'secondary'}
+          >
+            <Icons.plus />
+          </Button>
+        </SidebarGroupContent>
+      </SidebarGroup>
+      {/* TODO: Implement Notifications functionality */}
+      <SidebarGroup className="pl-0">
+        <SidebarGroupLabel>Notifications</SidebarGroupLabel>
+        <SidebarMenu>
+          <SidebarMenuItem>
+            <div className="flex items-center justify-between p-2 text-sm">
+              <span className="select-none">New posts</span>
+              <Switch defaultChecked />
+            </div>
+          </SidebarMenuItem>
+        </SidebarMenu>
+      </SidebarGroup>
+    </div>
+  );
+}

--- a/apps/app/src/components/layout/app-header.tsx
+++ b/apps/app/src/components/layout/app-header.tsx
@@ -18,7 +18,7 @@ import { useParams, usePathname } from 'next/navigation';
 import { pageTabs } from '@/config/page-tabs';
 
 export function AppHeader() {
-  const { isMobile, state } = useSidebar();
+  const { isMobile, leftState } = useSidebar();
   const pathname = usePathname();
   const { slug } = useParams<{ slug: string }>();
 
@@ -45,7 +45,7 @@ export function AppHeader() {
         <div
           className={cn(
             'flex h-full items-center',
-            isMobile || state === 'collapsed' ? 'flex' : 'hidden'
+            isMobile || leftState === 'collapsed' ? 'flex' : 'hidden'
           )}
         >
           <SidebarTrigger className="size-7 rounded-sm text-muted-foreground" />

--- a/apps/app/src/components/layout/app-sidebar/sidebar-layout.tsx
+++ b/apps/app/src/components/layout/app-sidebar/sidebar-layout.tsx
@@ -8,11 +8,11 @@ interface SidebarLayoutProps {
 }
 
 export function SidebarLayout({ children }: SidebarLayoutProps) {
-  const { isMobile, state } = useSidebar();
+  const { isMobile, leftState } = useSidebar();
   return (
     <div
       className={cn('flex w-full flex-col bg-sidebar py-2 pr-2', {
-        'pl-2': isMobile || state === 'collapsed',
+        'pl-2': isMobile || leftState === 'collapsed',
       })}
     >
       <SidebarInset className="bg-transparent">{children}</SidebarInset>

--- a/apps/app/src/components/layout/settings-sidebar/settings-sidebar.tsx
+++ b/apps/app/src/components/layout/settings-sidebar/settings-sidebar.tsx
@@ -26,7 +26,7 @@ interface SettingsSidebarProps {
 
 export function SettingsSidebar({ nav }: SettingsSidebarProps) {
   const pathname = usePathname();
-  const { toggleSidebar, isMobile } = useSidebar();
+  const { toggleLeftSidebar, isMobile } = useSidebar();
   return (
     <Sidebar className="p-0" variant="inset">
       <SidebarHeader>
@@ -57,7 +57,7 @@ export function SettingsSidebar({ nav }: SettingsSidebarProps) {
                         isActive={pathname === item.href}
                         onClick={() => {
                           if (isMobile) {
-                            toggleSidebar();
+                            toggleLeftSidebar();
                           }
                         }}
                       >

--- a/apps/app/src/hooks/use-space.ts
+++ b/apps/app/src/hooks/use-space.ts
@@ -5,3 +5,10 @@ export function useSpacesQuery() {
   const trpc = useTRPC();
   return useSuspenseQuery(trpc.space.getAll.queryOptions());
 }
+
+export function useSpaceWithPublishedPostsQuery(identifier: string) {
+  const trpc = useTRPC();
+  return useSuspenseQuery(
+    trpc.space.getSpaceWithPublishedPosts.queryOptions({ identifier })
+  );
+}

--- a/apps/app/src/lib/queries/index.ts
+++ b/apps/app/src/lib/queries/index.ts
@@ -97,3 +97,48 @@ export async function getPostByIdQuery(postId: string) {
     },
   });
 }
+
+export async function getSpaceWithPublishedPosts(
+  identifier: string,
+  workspaceId: string
+) {
+  return await database.space.findFirst({
+    where: {
+      identifier,
+      workspaceId,
+    },
+    include: {
+      posts: {
+        where: {
+          status: 'PUBLISHED',
+          resolvedAt: null,
+          archived: false,
+          publishedAt: { not: null },
+        },
+        orderBy: {
+          publishedAt: 'desc',
+        },
+        include: {
+          author: {
+            select: {
+              id: true,
+              name: true,
+              image: true,
+            },
+          },
+        },
+      },
+      members: {
+        select: {
+          user: {
+            select: {
+              id: true,
+              name: true,
+              image: true,
+            },
+          },
+        },
+      },
+    },
+  });
+}

--- a/apps/app/src/trpc/routers/post.ts
+++ b/apps/app/src/trpc/routers/post.ts
@@ -1,5 +1,5 @@
 import { TRPCError } from '@trpc/server';
-import { z } from 'zod';
+import { z } from 'zod/v4';
 import { createDraftPost, createNewPost } from '@/lib/mutations';
 import {
   getDraftPostsQuery,

--- a/apps/app/src/trpc/routers/space.ts
+++ b/apps/app/src/trpc/routers/space.ts
@@ -1,5 +1,6 @@
+import z from 'zod/v4';
 import { createNewSpace } from '@/lib/mutations';
-import { getSpacesQuery } from '@/lib/queries';
+import { getSpacesQuery, getSpaceWithPublishedPosts } from '@/lib/queries';
 import { createSpaceSchema } from '@/lib/schemas';
 import { createTRPCRouter, protectedProcedure } from '../init';
 
@@ -11,6 +12,14 @@ export const spaceRouter = createTRPCRouter({
       membersCount: _count.members,
     }));
   }),
+  getSpaceWithPublishedPosts: protectedProcedure
+    .input(z.object({ identifier: z.string() }))
+    .query(async ({ input, ctx: { workspaceId } }) => {
+      const { identifier } = input;
+      const space = await getSpaceWithPublishedPosts(identifier, workspaceId);
+
+      return space;
+    }),
   create: protectedProcedure
     .input(createSpaceSchema)
     .mutation(async ({ input, ctx: { db, session, workspaceId } }) => {

--- a/packages/database/src/prisma/schema.prisma
+++ b/packages/database/src/prisma/schema.prisma
@@ -170,7 +170,7 @@ model Space {
   workspace Workspace     @relation(fields: [workspaceId], references: [id], onDelete: Cascade)
   creator   User          @relation(fields: [createdBy], references: [id], onDelete: Cascade)
   members   SpaceMember[]
-  Post      Post[]
+  posts     Post[]
 
   @@unique([identifier, workspaceId])
   @@index([workspaceId])

--- a/packages/ui/src/components/sidebar.tsx
+++ b/packages/ui/src/components/sidebar.tsx
@@ -19,21 +19,29 @@ import { cva, type VariantProps } from 'class-variance-authority';
 import * as React from 'react';
 import { Icons } from '../lib/icons';
 
-const SIDEBAR_COOKIE_NAME = 'sidebar_state';
+const SIDEBAR_COOKIE_NAME_LEFT = 'sidebar_left_state';
+const SIDEBAR_COOKIE_NAME_RIGHT = 'sidebar_right_state';
 const SIDEBAR_COOKIE_MAX_AGE = 60 * 60 * 24 * 7;
 const SIDEBAR_WIDTH = '15rem';
 const SIDEBAR_WIDTH_MOBILE = '15rem';
 const SIDEBAR_WIDTH_ICON = '3rem';
-const SIDEBAR_KEYBOARD_SHORTCUT = '[';
+const SIDEBAR_KEYBOARD_SHORTCUT_LEFT = '[';
+const SIDEBAR_KEYBOARD_SHORTCUT_RIGHT = ']';
 
 type SidebarContextProps = {
-  state: 'expanded' | 'collapsed';
-  open: boolean;
-  setOpen: (open: boolean) => void;
-  openMobile: boolean;
-  setOpenMobile: (open: boolean) => void;
+  leftState: 'expanded' | 'collapsed';
+  rightState: 'expanded' | 'collapsed';
+  leftOpen: boolean;
+  rightOpen: boolean;
+  setLeftOpen: (open: boolean) => void;
+  setRightOpen: (open: boolean) => void;
+  leftOpenMobile: boolean;
+  rightOpenMobile: boolean;
+  setLeftOpenMobile: (open: boolean) => void;
+  setRightOpenMobile: (open: boolean) => void;
   isMobile: boolean;
-  toggleSidebar: () => void;
+  toggleLeftSidebar: () => void;
+  toggleRightSidebar: () => void;
 };
 
 const SidebarContext = React.createContext<SidebarContextProps | null>(null);
@@ -47,74 +55,157 @@ function useSidebar() {
   return context;
 }
 
+function useLeftSidebar() {
+  const {
+    leftState: state,
+    leftOpen: open,
+    setLeftOpen: setOpen,
+    leftOpenMobile: openMobile,
+    setLeftOpenMobile: setOpenMobile,
+    toggleLeftSidebar: toggleSidebar,
+    isMobile,
+  } = useSidebar();
+
+  return {
+    state,
+    open,
+    setOpen,
+    openMobile,
+    setOpenMobile,
+    toggleSidebar,
+    isMobile,
+  };
+}
+
+function useRightSidebar() {
+  const {
+    rightState: state,
+    rightOpen: open,
+    setRightOpen: setOpen,
+    rightOpenMobile: openMobile,
+    setRightOpenMobile: setOpenMobile,
+    toggleRightSidebar: toggleSidebar,
+    isMobile,
+  } = useSidebar();
+
+  return {
+    state,
+    open,
+    setOpen,
+    openMobile,
+    setOpenMobile,
+    toggleSidebar,
+    isMobile,
+  };
+}
+
 function SidebarProvider({
-  defaultOpen = true,
-  open: openProp,
-  onOpenChange: setOpenProp,
+  defaultLeftOpen = true,
+  defaultRightOpen = false,
+  leftOpen: leftOpenProp,
+  rightOpen: rightOpenProp,
+  onLeftOpenChange: setLeftOpenProp,
+  onRightOpenChange: setRightOpenProp,
   className,
   style,
   children,
   ...props
 }: React.ComponentProps<'div'> & {
-  defaultOpen?: boolean;
-  open?: boolean;
-  onOpenChange?: (open: boolean) => void;
+  defaultLeftOpen?: boolean;
+  defaultRightOpen?: boolean;
+  leftOpen?: boolean;
+  rightOpen?: boolean;
+  onLeftOpenChange?: (open: boolean) => void;
+  onRightOpenChange?: (open: boolean) => void;
 }) {
   const isMobile = useIsMobile();
-  const [openMobile, setOpenMobile] = React.useState(false);
+  const [leftOpenMobile, setLeftOpenMobile] = React.useState(false);
+  const [rightOpenMobile, setRightOpenMobile] = React.useState(false);
 
-  // This is the internal state of the sidebar.
-  // We use openProp and setOpenProp for control from outside the component.
-  const [_open, _setOpen] = React.useState(defaultOpen);
-  const open = openProp ?? _open;
-  const setOpen = React.useCallback(
+  // Internal state for left sidebar
+  const [_leftOpen, _setLeftOpen] = React.useState(defaultLeftOpen);
+  const leftOpen = leftOpenProp ?? _leftOpen;
+  const setLeftOpen = React.useCallback(
     (value: boolean | ((value: boolean) => boolean)) => {
-      const openState = typeof value === 'function' ? value(open) : value;
-      if (setOpenProp) {
-        setOpenProp(openState);
+      const openState = typeof value === 'function' ? value(leftOpen) : value;
+      if (setLeftOpenProp) {
+        setLeftOpenProp(openState);
       } else {
-        _setOpen(openState);
+        _setLeftOpen(openState);
       }
 
-      // This sets the cookie to keep the sidebar state.
-      document.cookie = `${SIDEBAR_COOKIE_NAME}=${openState}; path=/; max-age=${SIDEBAR_COOKIE_MAX_AGE}`;
+      // This sets the cookie to keep the left sidebar state.
+      document.cookie = `${SIDEBAR_COOKIE_NAME_LEFT}=${openState}; path=/; max-age=${SIDEBAR_COOKIE_MAX_AGE}`;
     },
-    [setOpenProp, open]
+    [setLeftOpenProp, leftOpen]
   );
 
-  // Helper to toggle the sidebar.
-  const toggleSidebar = React.useCallback(() => {
-    return isMobile ? setOpenMobile((open) => !open) : setOpen((open) => !open);
-  }, [isMobile, setOpen, setOpenMobile]);
+  // Internal state for right sidebar
+  const [_rightOpen, _setRightOpen] = React.useState(defaultRightOpen);
+  const rightOpen = rightOpenProp ?? _rightOpen;
+  const setRightOpen = React.useCallback(
+    (value: boolean | ((value: boolean) => boolean)) => {
+      const openState = typeof value === 'function' ? value(rightOpen) : value;
+      if (setRightOpenProp) {
+        setRightOpenProp(openState);
+      } else {
+        _setRightOpen(openState);
+      }
 
-  // Adds a keyboard shortcut to toggle the sidebar.
+      // This sets the cookie to keep the right sidebar state.
+      document.cookie = `${SIDEBAR_COOKIE_NAME_RIGHT}=${openState}; path=/; max-age=${SIDEBAR_COOKIE_MAX_AGE}`;
+    },
+    [setRightOpenProp, rightOpen]
+  );
+
+  // Helper to toggle the left sidebar.
+  const toggleLeftSidebar = React.useCallback(() => {
+    return isMobile ? setLeftOpenMobile((open) => !open) : setLeftOpen((open) => !open);
+  }, [isMobile, setLeftOpen, setLeftOpenMobile]);
+
+  // Helper to toggle the right sidebar.
+  const toggleRightSidebar = React.useCallback(() => {
+    return isMobile ? setRightOpenMobile((open) => !open) : setRightOpen((open) => !open);
+  }, [isMobile, setRightOpen, setRightOpenMobile]);
+
+  // Adds keyboard shortcuts to toggle the sidebars.
   React.useEffect(() => {
     const handleKeyDown = (event: KeyboardEvent) => {
-      if (event.key === SIDEBAR_KEYBOARD_SHORTCUT) {
+      if (event.key === SIDEBAR_KEYBOARD_SHORTCUT_LEFT) {
         event.preventDefault();
-        toggleSidebar();
+        toggleLeftSidebar();
+      } else if (event.key === SIDEBAR_KEYBOARD_SHORTCUT_RIGHT) {
+        event.preventDefault();
+        toggleRightSidebar();
       }
     };
 
     window.addEventListener('keydown', handleKeyDown);
     return () => window.removeEventListener('keydown', handleKeyDown);
-  }, [toggleSidebar]);
+  }, [toggleLeftSidebar, toggleRightSidebar]);
 
-  // We add a state so that we can do data-state="expanded" or "collapsed".
+  // We add states so that we can do data-state="expanded" or "collapsed".
   // This makes it easier to style the sidebar with Tailwind classes.
-  const state = open ? 'expanded' : 'collapsed';
+  const leftState = leftOpen ? 'expanded' : 'collapsed';
+  const rightState = rightOpen ? 'expanded' : 'collapsed';
 
   const contextValue = React.useMemo<SidebarContextProps>(
     () => ({
-      state,
-      open,
-      setOpen,
+      leftState,
+      rightState,
+      leftOpen,
+      rightOpen,
+      setLeftOpen,
+      setRightOpen,
       isMobile,
-      openMobile,
-      setOpenMobile,
-      toggleSidebar,
+      leftOpenMobile,
+      rightOpenMobile,
+      setLeftOpenMobile,
+      setRightOpenMobile,
+      toggleLeftSidebar,
+      toggleRightSidebar,
     }),
-    [state, open, setOpen, isMobile, openMobile, setOpenMobile, toggleSidebar]
+    [leftState, rightState, leftOpen, rightOpen, setLeftOpen, setRightOpen, isMobile, leftOpenMobile, rightOpenMobile, setLeftOpenMobile, setRightOpenMobile, toggleLeftSidebar, toggleRightSidebar]
   );
 
   return (
@@ -154,7 +245,19 @@ function Sidebar({
   variant?: 'sidebar' | 'floating' | 'inset';
   collapsible?: 'offcanvas' | 'icon' | 'none';
 }) {
-  const { isMobile, state, openMobile, setOpenMobile } = useSidebar();
+  const { 
+    isMobile, 
+    leftState, 
+    rightState, 
+    leftOpenMobile, 
+    rightOpenMobile, 
+    setLeftOpenMobile, 
+    setRightOpenMobile 
+  } = useSidebar();
+
+  const state = side === 'left' ? leftState : rightState;
+  const openMobile = side === 'left' ? leftOpenMobile : rightOpenMobile;
+  const setOpenMobile = side === 'left' ? setLeftOpenMobile : setRightOpenMobile;
 
   if (collapsible === 'none') {
     return (
@@ -245,11 +348,18 @@ function Sidebar({
 }
 
 function SidebarTrigger({
+  side = 'left',
   className,
   onClick,
   ...props
-}: React.ComponentProps<typeof Button>) {
-  const { toggleSidebar, state } = useSidebar();
+}: React.ComponentProps<typeof Button> & {
+  side?: 'left' | 'right';
+}) {
+  const { toggleLeftSidebar, toggleRightSidebar, leftState, rightState } = useSidebar();
+
+  const toggleSidebar = side === 'left' ? toggleLeftSidebar : toggleRightSidebar;
+  const state = side === 'left' ? leftState : rightState;
+  const shortcut = side === 'left' ? SIDEBAR_KEYBOARD_SHORTCUT_LEFT : SIDEBAR_KEYBOARD_SHORTCUT_RIGHT;
 
   return (
     <Button
@@ -261,25 +371,33 @@ function SidebarTrigger({
         toggleSidebar();
       }}
       size="icon"
-      tooltip={state === 'collapsed' ? 'Open sidebar' : 'Close sidebar'}
+      tooltip={state === 'collapsed' ? `Open ${side} sidebar` : `Close ${side} sidebar`}
       tooltipAlign={state === 'collapsed' ? 'start' : 'center'}
-      tooltipShortcut={SIDEBAR_KEYBOARD_SHORTCUT}
-      tooltipSide={state === 'collapsed' ? 'right' : 'bottom'}
+      tooltipShortcut={shortcut}
+      tooltipSide={state === 'collapsed' ? (side === 'left' ? 'right' : 'left') : 'bottom'}
       variant="ghost"
       {...props}
     >
-      <Icons.panelLeft />
-      <span className="sr-only">Toggle Sidebar</span>
+      {side === 'left' ? <Icons.panelLeft /> : <Icons.panelRight />}
+      <span className="sr-only">Toggle {side} Sidebar</span>
     </Button>
   );
 }
 
-function SidebarRail({ className, ...props }: React.ComponentProps<'button'>) {
-  const { toggleSidebar } = useSidebar();
+function SidebarRail({ 
+  side = 'left',
+  className, 
+  ...props 
+}: React.ComponentProps<'button'> & {
+  side?: 'left' | 'right';
+}) {
+  const { toggleLeftSidebar, toggleRightSidebar } = useSidebar();
+
+  const toggleSidebar = side === 'left' ? toggleLeftSidebar : toggleRightSidebar;
 
   return (
     <button
-      aria-label="Toggle Sidebar"
+      aria-label={`Toggle ${side} Sidebar`}
       className={cn(
         '-translate-x-1/2 group-data-[side=left]:-right-4 absolute inset-y-0 z-20 hidden w-4 transition-all ease-linear after:absolute after:inset-y-0 after:left-1/2 after:w-[2px] hover:after:bg-sidebar-border group-data-[side=right]:left-0 sm:flex',
         'in-data-[side=left]:cursor-w-resize in-data-[side=right]:cursor-e-resize',
@@ -293,7 +411,7 @@ function SidebarRail({ className, ...props }: React.ComponentProps<'button'>) {
       data-slot="sidebar-rail"
       onClick={toggleSidebar}
       tabIndex={-1}
-      title="Toggle Sidebar"
+      title={`Toggle ${side} Sidebar`}
       {...props}
     />
   );
@@ -497,6 +615,7 @@ function SidebarMenuButton({
   size = 'default',
   tooltip,
   tooltipShortcut,
+  side = 'left',
   className,
   ...props
 }: React.ComponentProps<'button'> & {
@@ -504,9 +623,12 @@ function SidebarMenuButton({
   isActive?: boolean;
   tooltip?: string | React.ReactNode;
   tooltipShortcut?: string;
+  side?: 'left' | 'right';
 } & VariantProps<typeof sidebarMenuButtonVariants>) {
   const Comp = asChild ? Slot : 'button';
-  const { isMobile, state } = useSidebar();
+  const { isMobile, leftState, rightState } = useSidebar();
+
+  const state = side === 'left' ? leftState : rightState;
 
   const button = (
     <Comp
@@ -529,7 +651,7 @@ function SidebarMenuButton({
       hideWhenDetached={state !== 'collapsed' || isMobile}
       label={tooltip}
       shortcut={tooltipShortcut}
-      side="right"
+      side={side === 'left' ? 'right' : 'left'}
     >
       {button}
     </Tooltip>
@@ -714,4 +836,6 @@ export {
   SidebarSeparator,
   SidebarTrigger,
   useSidebar,
+  useLeftSidebar,
+  useRightSidebar,
 };


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced dedicated left and right sidebar support, allowing independent toggling and control.
  * Added new components for space details, including a space header, published posts list grouped by date, and a sidebar with sections for about, members, and notifications.
  * Implemented a new page layout for viewing individual spaces with a main content area and a collapsible right sidebar.

* **Improvements**
  * Updated sidebar components and triggers throughout the app to support the new dual-sidebar system.
  * Enhanced responsiveness and layout of post and space components, including improved handling on different screen sizes.
  * Simplified and streamlined the management of sidebar state and toggling.

* **Bug Fixes**
  * Adjusted component rendering to ensure correct sidebar behavior and visibility across devices.

* **Chores**
  * Updated internal naming for consistency and maintainability (e.g., renaming relation fields and state variables).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->