### PR TITLE
feat: implement resolved post label and update post fetching logic

### DIFF
--- a/apps/app/src/app/[slug]/(sidebar)/posts/[id]/page.tsx
+++ b/apps/app/src/app/[slug]/(sidebar)/posts/[id]/page.tsx
@@ -9,17 +9,7 @@ export default async function PostPage({
   const { id } = await params;
 
   const queryClient = getQueryClient();
-  const post = await queryClient.fetchQuery(
-    trpc.post.getPostById.queryOptions({ id })
-  );
+  await queryClient.prefetchQuery(trpc.post.getPostById.queryOptions({ id }));
 
-  if (!post) {
-    return (
-      <div className="flex h-full items-center justify-center">
-        <p className="text-ui-gray-900">Post not found.</p>
-      </div>
-    );
-  }
-
-  return <PostPageContent post={post} />;
+  return <PostPageContent postId={id} />;
 }

--- a/apps/app/src/components/features/post/post-metadata.tsx
+++ b/apps/app/src/components/features/post/post-metadata.tsx
@@ -21,7 +21,7 @@ export function PostMetadata({
         src={userImage}
       />
       <div className="flex items-center gap-2 text-sm text-ui-gray-900">
-        <span className="font-medium text-primary ">{userName}</span>
+        <span className="font-medium text-primary">{userName}</span>
         <span>{formatDate(createdAt)}</span>
       </div>
     </div>

--- a/apps/app/src/components/features/post/post-options.tsx
+++ b/apps/app/src/components/features/post/post-options.tsx
@@ -39,7 +39,7 @@ interface PostOptionsProps {
 export function PostOptions({ postId }: PostOptionsProps) {
   const pathname = usePathname();
   const { mutate: deletePost } = useDeletePost();
-  const { mutate: resolvePost } = useResolvePost();
+  const { mutate: resolvePost } = useResolvePost(postId);
   const { mutate: movePostToSpace } = useMovePostToSpace(postId);
   const { mutate: pinPostToSpace } = usePinPostToSpace(postId);
   const { data: spaces } = useSpacesQuery();
@@ -100,11 +100,16 @@ export function PostOptions({ postId }: PostOptionsProps) {
         label: post?.pinned ? 'Unpin from space' : 'Pin to space',
         onClick: handlePinToSpace,
       },
-      {
-        icon: Icons.resolve,
-        label: 'Resolve post',
-        onClick: handleResolvePost,
-      },
+      ...(post?.resolvedAt
+        ? // TODO: Add "Unresolve post" option when post is resolved
+          []
+        : [
+            {
+              icon: Icons.resolve,
+              label: 'Resolve post',
+              onClick: handleResolvePost,
+            },
+          ]),
     ].filter(Boolean),
     [
       {

--- a/apps/app/src/components/features/post/post-page-content.tsx
+++ b/apps/app/src/components/features/post/post-page-content.tsx
@@ -12,30 +12,25 @@ import { PostActivitySection } from '@/components/features/post/post-activity-se
 import { PostMetadata } from '@/components/features/post/post-metadata';
 import { PostOptions } from '@/components/features/post/post-options';
 import { PostSidebar } from '@/components/features/post/post-sidebar';
+import { ResolvedPostLabel } from '@/components/features/post/resolved-post-label';
 import { PageHeader } from '@/components/layout/page-header';
-
-interface Post {
-  id: string;
-  title: string;
-  content: string | null;
-  createdAt: Date;
-  author: {
-    name: string;
-    image: string | null;
-  };
-  space: {
-    name: string;
-    identifier: string;
-    icon: string | null;
-  };
-}
+import { usePostByIdQuery } from '@/hooks/use-posts';
 
 interface PostPageContentProps {
-  post: Post;
+  postId: string;
 }
 
-export function PostPageContent({ post }: PostPageContentProps) {
+export function PostPageContent({ postId }: PostPageContentProps) {
   const { slug } = useParams<{ slug: string }>();
+  const { data: post } = usePostByIdQuery(postId);
+
+  if (!post) {
+    return (
+      <div className="flex h-full items-center justify-center">
+        <p className="text-ui-gray-900">Post not found.</p>
+      </div>
+    );
+  }
 
   return (
     <div className="flex h-full w-full">
@@ -49,7 +44,7 @@ export function PostPageContent({ post }: PostPageContentProps) {
                 ) : (
                   <Icons.space size={16} />
                 ),
-                label: post.space?.name,
+                label: post.space?.name || 'Space',
                 href: `/${slug}/spaces/${post.space.identifier}`,
               },
               {
@@ -71,10 +66,16 @@ export function PostPageContent({ post }: PostPageContentProps) {
           />
           <div className="flex-1 overflow-auto">
             <ActivitySection>
+              {post.resolvedAt && post.resolvedById && (
+                <ResolvedPostLabel
+                  resolvedAt={post.resolvedAt}
+                  userName={post.resolvedBy?.name || ''}
+                />
+              )}
               <PostMetadata
                 createdAt={post.createdAt}
                 userImage={post.author.image || ''}
-                userName={post.author.name}
+                userName={post.author.name || ''}
               />
               <EditablePostContent
                 initialContent={post.content}
@@ -105,8 +106,8 @@ export function PostPageContent({ post }: PostPageContentProps) {
         <SidebarContent>
           <PostSidebar
             postId={post.id}
-            spaceIcon={post.space.icon}
-            spaceName={post.space.name}
+            spaceIcon={post.space.icon || null}
+            spaceName={post.space.name || ''}
           />
         </SidebarContent>
       </Sidebar>

--- a/apps/app/src/components/features/post/resolved-post-label.tsx
+++ b/apps/app/src/components/features/post/resolved-post-label.tsx
@@ -1,0 +1,25 @@
+import { Badge } from '@coordinize/ui/badge';
+
+import { formatDate } from '@/utils/format-date';
+
+interface ResolvedPostLabelProps {
+  userName: string;
+  resolvedAt: Date;
+}
+
+export function ResolvedPostLabel({
+  userName,
+  resolvedAt,
+}: ResolvedPostLabelProps) {
+  return (
+    <div className="flex items-center gap-2">
+      <Badge className="rounded-sm bg-ui-green-700 px-2 py-0.5 uppercase">
+        Resolved
+      </Badge>
+      <div className="flex items-center gap-2 text-sm text-ui-gray-900">
+        <span className="font-medium text-ui-gray-900">{userName}</span>
+        <span className="text-ui-gray-800">{formatDate(resolvedAt)}</span>
+      </div>
+    </div>
+  );
+}

--- a/apps/app/src/hooks/use-posts.ts
+++ b/apps/app/src/hooks/use-posts.ts
@@ -93,10 +93,9 @@ export function useDeletePost() {
   );
 }
 
-export function useResolvePost() {
+export function useResolvePost(postId: string) {
   const trpc = useTRPC();
   const queryClient = useQueryClient();
-  const router = useRouter();
 
   return useMutation(
     trpc.post.resolve.mutationOptions({
@@ -105,9 +104,14 @@ export function useResolvePost() {
         queryClient.invalidateQueries({
           queryKey: trpc.post.getAllPublished.queryKey(),
         });
-      },
-      onSettled: () => {
-        router.back();
+        queryClient.invalidateQueries({
+          queryKey: trpc.post.getPostById.queryKey({
+            id: postId,
+          }),
+        });
+        queryClient.invalidateQueries({
+          queryKey: trpc.space.getSpaceWithPublishedPosts.queryKey(),
+        });
       },
     })
   );

--- a/apps/app/src/lib/queries/index.ts
+++ b/apps/app/src/lib/queries/index.ts
@@ -96,6 +96,7 @@ export async function getPostByIdQuery(postId: string) {
         },
       },
       author: { select: { id: true, name: true, image: true } },
+      resolvedBy: { select: { id: true, name: true, image: true } },
     },
   });
 }


### PR DESCRIPTION
# Description

This PR adds `RESOLVED` post label, the post which are resolved.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a "Resolved" label to posts that have been marked as resolved, showing the resolver's name and resolution date.

* **Improvements**
  * Post pages now handle missing or incomplete data more gracefully, providing default values where necessary.
  * The "Resolve post" option is now only shown for unresolved posts; resolved posts will omit this option.
  * Enhanced data fetching for post details, including information about the user who resolved the post.

* **Bug Fixes**
  * Minor styling correction in post metadata display.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->