### PR TITLE
feat: add space settings pages

### DIFF
--- a/apps/app/src/app/[slug]/settings/spaces/[identifier]/general/page.tsx
+++ b/apps/app/src/app/[slug]/settings/spaces/[identifier]/general/page.tsx
@@ -1,0 +1,24 @@
+import { Label } from '@coordinize/ui/components/label';
+import { SpaceDetailsForm } from '@/components/settings/spaces/space-details-form';
+import { HydrateClient, prefetch, trpc } from '@/trpc/server';
+
+export default async function SpaceSettingsPage({
+  params,
+}: {
+  params: Promise<{ slug: string; identifier: string }>;
+}) {
+  const { identifier } = await params;
+
+  prefetch(trpc.space.getById.queryOptions({ id: identifier }));
+
+  return (
+    <HydrateClient>
+      <div className="flex flex-col gap-6">
+        <div className="flex flex-col gap-4">
+          <Label className="text-muted-foreground">General</Label>
+          <SpaceDetailsForm identifier={identifier} />
+        </div>
+      </div>
+    </HydrateClient>
+  );
+}

--- a/apps/app/src/app/[slug]/settings/spaces/[identifier]/members/page.tsx
+++ b/apps/app/src/app/[slug]/settings/spaces/[identifier]/members/page.tsx
@@ -1,0 +1,41 @@
+import { Label } from '@coordinize/ui/components/label';
+
+import { MembersTable } from '@/components/settings/members/members-table';
+import { getQueryClient, HydrateClient, trpc } from '@/trpc/server';
+
+export default async function SpaceMembersPage({
+  params,
+}: {
+  params: Promise<{ slug: string; identifier: string }>;
+}) {
+  const { slug: _slug, identifier } = await params;
+
+  const queryClient = getQueryClient();
+  const spaceMembers = await queryClient.fetchQuery(
+    trpc.space.getMembersBySpaceId.queryOptions({ id: identifier })
+  );
+
+  if (!spaceMembers) {
+    return <div>Loading...</div>;
+  }
+
+  const data = spaceMembers.map((member) => {
+    return {
+      imageSrc: member.user?.image,
+      name: member.user?.name,
+      email: member.user?.email,
+      status: member.role,
+      joinedAt: member.joined,
+    };
+  });
+  return (
+    <HydrateClient>
+      <div className="flex flex-col gap-6">
+        <div className="flex flex-col gap-4">
+          <Label className="text-muted-foreground">Members</Label>
+          <MembersTable data={data} />
+        </div>
+      </div>
+    </HydrateClient>
+  );
+}

--- a/apps/app/src/app/[slug]/settings/spaces/[identifier]/page.tsx
+++ b/apps/app/src/app/[slug]/settings/spaces/[identifier]/page.tsx
@@ -1,0 +1,11 @@
+import { redirect } from 'next/navigation';
+
+export default async function SettingsPage({
+  params,
+}: {
+  params: Promise<{ slug: string; identifier: string }>;
+}) {
+  const { slug, identifier } = await params;
+
+  redirect(`/${slug}/settings/spaces/${identifier}/general`);
+}

--- a/apps/app/src/components/features/post/post-sidebar.tsx
+++ b/apps/app/src/components/features/post/post-sidebar.tsx
@@ -29,10 +29,12 @@ export function PostSidebar({
         <SidebarGroup className="pl-2 sm:pl-0">
           <SidebarGroupLabel>Subscribe</SidebarGroupLabel>
           <SidebarMenu>
-            <SidebarMenuItem>
+            <SidebarMenuItem className="cursor-default">
               <div className="flex items-center justify-between p-2 text-sm">
-                <span className="select-none">New Activity</span>
-                <Switch defaultChecked />
+                <span className="select-none text-ui-gray-800">
+                  New Activity
+                </span>
+                <Switch disabled />
               </div>
             </SidebarMenuItem>
           </SidebarMenu>

--- a/apps/app/src/components/features/space/space-sidebar.tsx
+++ b/apps/app/src/components/features/space/space-sidebar.tsx
@@ -29,7 +29,7 @@ export function SpaceSidebar({ identifier }: SpaceSidebarProps) {
           {space?.about || 'No description available.'}
         </p>
       </SidebarGroup>
-      <SidebarGroup className="pl-2 sm:pl-0">
+      <SidebarGroup className="hidden pl-2 sm:pl-0">
         <SidebarGroupLabel>
           {membersCount} member{membersCount !== 1 ? 's' : ''}
         </SidebarGroupLabel>
@@ -44,6 +44,7 @@ export function SpaceSidebar({ identifier }: SpaceSidebarProps) {
                 className="size-6"
                 fallback={member.user.name}
                 src={member.user.image ?? ''}
+                statusShow={false}
               />
             </div>
           ))}
@@ -58,7 +59,7 @@ export function SpaceSidebar({ identifier }: SpaceSidebarProps) {
         </SidebarGroupContent>
       </SidebarGroup>
       {/* TODO: Implement Notifications functionality */}
-      <SidebarGroup className="pl-2 sm:pl-0">
+      <SidebarGroup className="hidden pl-2 sm:pl-0">
         <SidebarGroupLabel>Notifications</SidebarGroupLabel>
         <SidebarMenu>
           <SidebarMenuItem>

--- a/apps/app/src/components/forms/auto-save-form.tsx
+++ b/apps/app/src/components/forms/auto-save-form.tsx
@@ -1,0 +1,40 @@
+'use client';
+
+import { toast } from '@coordinize/ui/components/sonner';
+import { useCallback } from 'react';
+import type { FieldValues, Path, UseFormReturn } from 'react-hook-form';
+
+interface UseAutoSaveFormOptions<T extends FieldValues> {
+  form: UseFormReturn<T>;
+  initialValues: T;
+  onSubmit: (values: T) => void;
+}
+
+export function useAutoSaveForm<T extends FieldValues>({
+  form,
+  initialValues,
+  onSubmit,
+}: UseAutoSaveFormOptions<T>) {
+  const handleFieldBlur = useCallback(
+    async (fieldName: Path<T>) => {
+      const isValid = await form.trigger(fieldName);
+      if (!isValid) {
+        const error = form.getFieldState(fieldName).error;
+        if (error?.message) {
+          toast.error(error.message);
+        }
+        return;
+      }
+
+      const currentValue = form.getValues(fieldName);
+      const initialValue = initialValues[fieldName];
+
+      if (currentValue !== initialValue) {
+        form.handleSubmit(onSubmit)();
+      }
+    },
+    [form, initialValues, onSubmit]
+  );
+
+  return { handleFieldBlur };
+}

--- a/apps/app/src/components/layout/app-sidebar/team-switcher.tsx
+++ b/apps/app/src/components/layout/app-sidebar/team-switcher.tsx
@@ -44,9 +44,9 @@ export function TeamSwitcher({ email }: { email: string }) {
         <DropdownMenu>
           <DropdownMenuTrigger asChild className="h-8">
             <SidebarMenuButton className="w-fit focus-visible:ring-0">
-              <Avatar className="size-5 rounded border">
+              <Avatar className="size-5 overflow-hidden rounded border">
                 <AvatarImage alt="workspace-logo" src={workspace?.logo ?? ''} />
-                <AvatarFallback className="select-none">
+                <AvatarFallback className="select-none rounded-none">
                   {workspace?.name.at(0)?.toUpperCase()}
                 </AvatarFallback>
               </Avatar>

--- a/apps/app/src/components/settings/profile/preferred-name-form.tsx
+++ b/apps/app/src/components/settings/profile/preferred-name-form.tsx
@@ -4,10 +4,10 @@ import { toast } from '@coordinize/ui/components/sonner';
 import { Form, FormControl, FormField, FormItem } from '@coordinize/ui/form';
 import { Input } from '@coordinize/ui/input';
 import { zodResolver } from '@hookform/resolvers/zod';
-import { useAction } from 'next-safe-action/hooks';
+import { useMutation } from '@tanstack/react-query';
 import { useForm, useFormState } from 'react-hook-form';
 import { z } from 'zod';
-import { updateProfileAction } from '@/actions/update-user-action';
+import { useTRPC } from '@/trpc/client';
 
 const formSchema = z.object({
   preferredName: z
@@ -20,22 +20,26 @@ interface PreferredNameFormProps {
 }
 
 export function PreferredNameForm({ name }: PreferredNameFormProps) {
+  const trpc = useTRPC();
+
   const form = useForm<z.infer<typeof formSchema>>({
     resolver: zodResolver(formSchema),
     defaultValues: { preferredName: name ?? '' },
   });
 
-  const { execute } = useAction(updateProfileAction, {
-    onError: () => {
-      toast.error('Something went wrong.');
-    },
-    onSuccess: () => {
-      toast.success('Your preferred name has been updated.');
-    },
-  });
+  const { mutate: updateProfile } = useMutation(
+    trpc.user.updateProfile.mutationOptions({
+      onError: () => {
+        toast.error('Something went wrong.');
+      },
+      onSuccess: () => {
+        toast.success('Your preferred name has been updated.');
+      },
+    })
+  );
 
   function onSubmit(values: z.infer<typeof formSchema>) {
-    execute({ ...values });
+    updateProfile({ preferredName: values.preferredName });
   }
 
   const { isDirty } = useFormState({ control: form.control });

--- a/apps/app/src/components/settings/spaces/space-details-form.tsx
+++ b/apps/app/src/components/settings/spaces/space-details-form.tsx
@@ -1,0 +1,231 @@
+'use client';
+
+import { Button } from '@coordinize/ui/components/button';
+import {
+  EmojiPicker,
+  EmojiPickerContent,
+  EmojiPickerSearch,
+} from '@coordinize/ui/components/emoji-picker';
+import {
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+} from '@coordinize/ui/components/form';
+import { Input } from '@coordinize/ui/components/input';
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from '@coordinize/ui/components/popover';
+import { toast } from '@coordinize/ui/components/sonner';
+import { Textarea } from '@coordinize/ui/components/textarea';
+import { Icons } from '@coordinize/ui/lib/icons';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { useMutation, useQuery } from '@tanstack/react-query';
+import { useCallback, useEffect, useMemo } from 'react';
+import { useForm } from 'react-hook-form';
+import { z } from 'zod';
+import { useAutoSaveForm } from '@/components/forms/auto-save-form';
+import { SettingsCard } from '@/components/settings/settings-card';
+import { useTRPC } from '@/trpc/client';
+
+const formSchema = z.object({
+  id: z.string(),
+  name: z.string().min(3, { message: 'Name must be at least 3 characters.' }),
+  identifier: z
+    .string()
+    .min(3, { message: 'Identifier must be at least 3 characters.' }),
+  about: z.string().optional(),
+  icon: z.string().optional(),
+});
+
+export function SpaceDetailsForm({ identifier }: { identifier: string }) {
+  const trpc = useTRPC();
+
+  const { data: space } = useQuery(
+    trpc.space.getById.queryOptions({ id: identifier })
+  );
+
+  const initialValues = useMemo(
+    () => ({
+      id: space?.id || '',
+      name: space?.name || '',
+      identifier: space?.identifier || '',
+      about: space?.about || '',
+      icon: space?.icon || '',
+    }),
+    [space?.id, space?.name, space?.identifier, space?.about, space?.icon]
+  );
+
+  const form = useForm<z.infer<typeof formSchema>>({
+    resolver: zodResolver(formSchema),
+    defaultValues: initialValues,
+  });
+
+  useEffect(() => {
+    if (space) {
+      form.reset({
+        id: space.id,
+        name: space.name || '',
+        identifier: space.identifier || '',
+        about: space.about || '',
+        icon: space.icon || '',
+      });
+    }
+  }, [space, form]);
+
+  const { mutate: updateSpace } = useMutation(
+    trpc.space.update.mutationOptions({
+      onError: () => {
+        toast.error('Something went wrong!');
+      },
+      onSuccess: () => {
+        toast.success('Space updated.');
+      },
+    })
+  );
+
+  const onSubmit = useCallback(
+    (values: z.infer<typeof formSchema>) => {
+      updateSpace(values);
+    },
+    [updateSpace]
+  );
+
+  const { handleFieldBlur } = useAutoSaveForm({
+    form,
+    initialValues,
+    onSubmit,
+  });
+
+  if (!space) {
+    return <div className="text-ui-gray-900">Loading...</div>;
+  }
+
+  return (
+    <Form {...form}>
+      <form className="space-y-4" onSubmit={form.handleSubmit(onSubmit)}>
+        <SettingsCard
+          className="flex-col items-start lg:flex-row lg:items-center lg:justify-between"
+          description="Choose an emoji to represent your space."
+          title="Space Icon"
+        >
+          <FormField
+            control={form.control}
+            name="icon"
+            render={({ field }) => (
+              <FormItem className="w-full md:w-96">
+                <FormControl>
+                  <Popover>
+                    <PopoverTrigger asChild>
+                      <Button
+                        className="shadow-none"
+                        onBlur={() => handleFieldBlur('icon')}
+                        size={'icon'}
+                        type="button"
+                        variant="outline"
+                      >
+                        {field.value || <Icons.emojiPlus className="h-5 w-5" />}
+                      </Button>
+                    </PopoverTrigger>
+                    <PopoverContent align="start" className="w-fit p-0">
+                      <EmojiPicker
+                        className="h-[342px]"
+                        onEmojiSelect={({ emoji }) => {
+                          field.onChange(emoji);
+                          // Trigger blur after emoji selection
+                          setTimeout(() => handleFieldBlur('icon'), 100);
+                        }}
+                      >
+                        <EmojiPickerSearch />
+                        <EmojiPickerContent />
+                      </EmojiPicker>
+                    </PopoverContent>
+                  </Popover>
+                </FormControl>
+              </FormItem>
+            )}
+          />
+        </SettingsCard>
+
+        <SettingsCard
+          className="flex-col items-start lg:flex-row lg:items-center lg:justify-between"
+          description="Spaces are dedicated areas within a workspace where team members can collaborate and share posts."
+          title="Space Name"
+        >
+          <FormField
+            control={form.control}
+            name="name"
+            render={({ field }) => (
+              <FormItem className="w-full md:w-96">
+                <FormControl>
+                  <Input
+                    {...field}
+                    className={`w-full shadow-none ${
+                      form.getValues('name') ? 'bg-input' : ''
+                    }`}
+                    onBlur={() => handleFieldBlur('name')}
+                    placeholder="e.g. Engineering"
+                    type="text"
+                  />
+                </FormControl>
+              </FormItem>
+            )}
+          />
+        </SettingsCard>
+
+        <SettingsCard
+          className="flex-col items-start lg:flex-row lg:items-center lg:justify-between"
+          description="Used to identify this space. (e.g. ENG)"
+          title="Identifier"
+        >
+          <FormField
+            control={form.control}
+            name="identifier"
+            render={({ field }) => (
+              <FormItem className="w-full md:w-96">
+                <FormControl>
+                  <Input
+                    {...field}
+                    className={`w-full shadow-none ${
+                      form.getValues('identifier') ? 'bg-input' : ''
+                    }`}
+                    onBlur={() => handleFieldBlur('identifier')}
+                    placeholder="e.g. ENG"
+                    type="text"
+                  />
+                </FormControl>
+              </FormItem>
+            )}
+          />
+        </SettingsCard>
+
+        <SettingsCard
+          className="flex-col items-start lg:flex-row lg:justify-between"
+          description="A brief description about this space and its purpose."
+          title="About"
+        >
+          <FormField
+            control={form.control}
+            name="about"
+            render={({ field }) => (
+              <FormItem className="w-full md:w-96">
+                <FormControl>
+                  <Textarea
+                    {...field}
+                    className={`shadow-none ${
+                      form.getValues('about') ? 'bg-input' : ''
+                    }`}
+                    onBlur={() => handleFieldBlur('about')}
+                    placeholder="Write something about..."
+                  />
+                </FormControl>
+              </FormItem>
+            )}
+          />
+        </SettingsCard>
+      </form>
+    </Form>
+  );
+}

--- a/apps/app/src/config/team-navigation.ts
+++ b/apps/app/src/config/team-navigation.ts
@@ -8,12 +8,12 @@ export function getSpaceNavigation(spaceId: string, slug: string): NavItem[] {
   return [
     {
       label: 'General',
-      href: `/${slug}/settings/space/${spaceId}/general`,
+      href: `/${slug}/settings/spaces/${spaceId}/general`,
       icon: 'settings',
     },
     {
       label: 'Members',
-      href: `/${slug}/settings/space/${spaceId}/members`,
+      href: `/${slug}/settings/spaces/${spaceId}/members`,
       icon: 'members',
     },
   ];

--- a/apps/app/src/trpc/routers/space.ts
+++ b/apps/app/src/trpc/routers/space.ts
@@ -61,6 +61,35 @@ export const spaceRouter = createTRPCRouter({
 
       return space;
     }),
+  getMembersBySpaceId: protectedProcedure
+    .input(z.object({ id: z.string() }))
+    .query(async ({ input, ctx: { db, workspaceId } }) => {
+      const { id } = input;
+
+      const spaceMembers = await db.spaceMember.findMany({
+        where: {
+          space: {
+            identifier: id,
+            workspaceId,
+          },
+        },
+        include: {
+          user: {
+            select: {
+              id: true,
+              name: true,
+              image: true,
+              email: true,
+            },
+          },
+        },
+        orderBy: {
+          joined: 'asc',
+        },
+      });
+
+      return spaceMembers;
+    }),
   create: protectedProcedure
     .input(createSpaceSchema)
     .mutation(async ({ input, ctx: { db, session, workspaceId } }) => {

--- a/apps/app/src/trpc/routers/space.ts
+++ b/apps/app/src/trpc/routers/space.ts
@@ -1,8 +1,22 @@
-import z from 'zod/v4';
+import z, { string } from 'zod/v4';
 import { createNewSpace } from '@/lib/mutations';
 import { getSpacesQuery, getSpaceWithPublishedPosts } from '@/lib/queries';
 import { createSpaceSchema } from '@/lib/schemas';
 import { createTRPCRouter, protectedProcedure } from '../init';
+
+const updateSpaceSchema = z.object({
+  id: z.string(),
+  name: z
+    .string()
+    .min(3, { message: 'Name must be at least 3 characters.' })
+    .optional(),
+  identifier: z
+    .string()
+    .min(3, { message: 'Identifier must be at least 3 characters.' })
+    .optional(),
+  about: z.string().optional(),
+  icon: z.string().optional(),
+});
 
 export const spaceRouter = createTRPCRouter({
   getAll: protectedProcedure.query(async ({ ctx: { workspaceId } }) => {
@@ -12,6 +26,33 @@ export const spaceRouter = createTRPCRouter({
       membersCount: _count.members,
     }));
   }),
+  getById: protectedProcedure
+    .input(z.object({ id: string() }))
+    .query(async ({ input, ctx: { db, workspaceId } }) => {
+      const { id } = input;
+      const space = await db.space.findFirst({
+        where: { identifier: id, workspaceId },
+        include: {
+          members: {
+            select: {
+              user: {
+                select: {
+                  id: true,
+                  name: true,
+                  image: true,
+                },
+              },
+            },
+          },
+        },
+      });
+
+      if (!space) {
+        throw new Error('Space not found');
+      }
+
+      return space;
+    }),
   getSpaceWithPublishedPosts: protectedProcedure
     .input(z.object({ identifier: z.string() }))
     .query(async ({ input, ctx: { workspaceId } }) => {
@@ -38,5 +79,38 @@ export const spaceRouter = createTRPCRouter({
       return {
         workspaceSlug: session.user.defaultWorkspace,
       };
+    }),
+  update: protectedProcedure
+    .input(updateSpaceSchema)
+    .mutation(async ({ input, ctx: { db, workspaceId } }) => {
+      const { id, name, identifier, about, icon } = input;
+
+      // Build update object dynamically
+      const updateData: Record<string, string | null> = {};
+      if (name !== undefined) {
+        updateData.name = name;
+      }
+      if (identifier !== undefined) {
+        updateData.identifier = identifier;
+      }
+      if (about !== undefined) {
+        updateData.about = about;
+      }
+      if (icon !== undefined) {
+        updateData.icon = icon;
+      }
+
+      // Update only if there's something to update
+      if (Object.keys(updateData).length > 0) {
+        await db.space.update({
+          where: {
+            id,
+            workspaceId, // Ensure the space belongs to the current workspace
+          },
+          data: updateData,
+        });
+      }
+
+      return { success: true };
     }),
 });

--- a/apps/app/src/trpc/routers/user.ts
+++ b/apps/app/src/trpc/routers/user.ts
@@ -31,6 +31,39 @@ export const userRouter = createTRPCRouter({
       return user;
     }),
 
+  updateProfile: protectedProcedure
+    .input(
+      z.object({
+        preferredName: z
+          .string()
+          .min(1, { message: 'Name is required.' })
+          .optional(),
+        image: z.string().optional(),
+      })
+    )
+    .mutation(async ({ input, ctx: { db, session } }) => {
+      const { preferredName, image } = input;
+
+      // Build update object dynamically
+      const updateData: Record<string, string> = {};
+      if (preferredName) {
+        updateData.name = preferredName;
+      }
+      if (image !== undefined) {
+        updateData.image = image;
+      }
+
+      // Update only if there's something to update
+      if (Object.keys(updateData).length > 0) {
+        await db.user.update({
+          where: { id: session.user.id },
+          data: updateData,
+        });
+      }
+
+      return { success: true };
+    }),
+
   updateOnboarding: authenticatedProcedure.mutation(
     async ({ ctx: { db, session } }) => {
       const user = await db.user.update({


### PR DESCRIPTION
# Description

This PR adds settings spaces sub pages `General Page` and `Members Page`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added pages to view and edit space settings and members, with server-side data fetching and client-side hydration.
  * Introduced a form for editing space details, including name, identifier, description, and icon, with auto-save on field blur.
  * Added new backend capabilities to fetch and update space details, space members, user profile, and workspace information.

* **Bug Fixes**
  * Updated navigation links for space settings to use the correct URL path.

* **Refactor**
  * Improved form submission and auto-save logic for workspace and profile settings, using a reusable auto-save hook and enhanced mutation handling.

* **Style**
  * Adjusted sidebar and avatar styles for improved appearance.
  * Made certain sidebar items and options visually and functionally inactive or hidden.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->